### PR TITLE
add github actions CI

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -9,7 +9,7 @@ jobs:
         config: [Gcc-shared-debug, Clang-shared-debug, Clang-static-release]
     steps:
       - name: Install system packages
-        run: sudo apt-get install python3-setuptools graphviz clang-format-10 clang-10
+        run: sudo apt-get install python3-setuptools graphviz clang-format-10 clang-10 clang-tidy-10 ninja
       - name: install conan
         run: pip3 install conan --ignore-installed 
       - uses: actions/checkout@v2

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -12,7 +12,7 @@ jobs:
         run: sudo apt-get install python3-setuptools
       - name: install
         run: pip3 install conan --ignore-installed 
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           submodules: "recursive"
       - name: run
@@ -37,7 +37,7 @@ jobs:
       matrix:
         config: ["VS2019-shared-debug", "VS2019-static-release"]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           submodules: "recursive"
       - name: run

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,0 +1,40 @@
+on: [push, pull_request]
+
+jobs:
+  linux:
+    runs-on:  ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        config: ["Gcc-shared-debug", "Clang-shared-debug", "Clang-static-release"]
+    steps:
+      - name: Install Python
+        run: apt-get update && apt-get -qq install -y --no-install-recommends python3-pip python3-setuptools g++ pkg-config cmake
+      - name: install
+        run: pip3 install conan --ignore-installed 
+      - uses: actions/checkout@v1
+      - name: run
+        shell: bash
+        env:
+          CONAN_SYSREQUIRES_MODE: enabled
+          CONAN_SYSREQUIRES_SUDO: 0
+        run: |
+          python3 Sources/CPFBuildScripts/0_CopyScripts.py
+          python3 1_Configure.py ${{ matrix.config }}
+          python3 3_Generate.py
+          python3 4_Make.py --target runAllTests_QtTestConsumer
+
+  Windows:
+    runs-on:  windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        config: ["VS2019-shared-debug", "VS2019-static-release"]
+    steps:
+      - uses: actions/checkout@v1
+      - name: run
+        run: |
+          python Sources/CPFBuildScripts/0_CopyScripts.py
+          python 1_Configure.py ${{ matrix.config }}
+          python 3_Generate.py
+          python 4_Make.py --target runAllTests_QtTestConsumer

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -14,7 +14,7 @@ jobs:
         run: pip3 install conan --ignore-installed 
       - uses: actions/checkout@v2
         with:
-          submodules: "recursive"
+          submodules: True
       - name: run
         shell: bash
         env:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -8,6 +8,8 @@ jobs:
       matrix:
         config: ["Gcc-shared-debug", "Clang-shared-debug", "Clang-static-release"]
     steps:
+      - name: Install setuptools
+        run: sudo apt-get install python3-setuptools
       - name: install
         run: pip3 install conan --ignore-installed 
       - uses: actions/checkout@v1

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -9,29 +9,17 @@ jobs:
         config: [Gcc-shared-debug, Clang-shared-debug, Clang-static-release]
     steps:
       - name: Install setuptools
-        run: sudo apt-get install python3-setuptools
+        run: sudo apt-get install python3-setuptools graphviz
       - name: install
         run: pip3 install conan --ignore-installed 
       - uses: actions/checkout@v2
-      - uses: actions/checkout@v2
         with:
-          repository: Knitschi/CPFCMake
-          path: Sources/CPFCMake
-      - uses: actions/checkout@v2
-        with:
-          repository: Knitschi/CIBuildConfigurations
-          path: Sources/CIBuildConfigurations
-      - uses: actions/checkout@v2
-        with:
-          repository: Knitschi/CPFBuildscripts
-          path: Sources/CPFBuildscripts
-        
+          submodules: recursive        
       - name: run
         env:
           CONAN_SYSREQUIRES_MODE: enabled
           CONAN_SYSREQUIRES_SUDO: 0
         run: |
-          pushd Sources && ls -al && popd
           python3 Sources/CPFBuildscripts/0_CopyScripts.py
           python3 1_Configure.py ${{ matrix.config }}
           python3 3_Generate.py

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -6,15 +6,26 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        config: ["Gcc-shared-debug", "Clang-shared-debug", "Clang-static-release"]
+        config: [Gcc-shared-debug, Clang-shared-debug, Clang-static-release]
     steps:
       - name: Install setuptools
         run: sudo apt-get install python3-setuptools
       - name: install
         run: pip3 install conan --ignore-installed 
       - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
         with:
-          submodules: recursive
+          repository: Knitschi/CPFCMake
+          path: Sources/CPFCMake
+      - uses: actions/checkout@v2
+        with:
+          repository: Knitschi/CIBuildConfigurations
+          path: Sources/CIBuildConfigurations
+      - uses: actions/checkout@v2
+        with:
+          repository: Knitschi/CPFBuildscripts
+          path: Sources/CPFBuildscripts
+        
       - name: run
         env:
           CONAN_SYSREQUIRES_MODE: enabled
@@ -31,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        config: ["VS2019-shared-debug", "VS2019-static-release"]
+        config: [VS2019-shared-debug, VS2019-static-release]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -32,7 +32,7 @@ jobs:
           CONAN_SYSREQUIRES_SUDO: 0
         run: |
           pushd Sources && ls -al && popd
-          pushd Sources/CPFBuildScripts/ && ls -al && popd
+          python3 Sources/CPFBuildScripts/0_CopyScripts.py
           python3 1_Configure.py ${{ matrix.config }}
           python3 3_Generate.py
           python3 4_Make.py --target runAllTests_QtTestConsumer

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -22,9 +22,9 @@ jobs:
           CONAN_SYSREQUIRES_SUDO: 0
         run: |
           pwd
-          ls -al
-          ls -al Sources
-          ls -al Sources/CPFBuildScripts
+          ls -al ./
+          ls -al Sources/
+          ls -al Sources/CPFBuildScripts/
           ls -al Sources/CPFBuildScripts/0_CopyScripts.py
           python3 1_Configure.py ${{ matrix.config }}
           python3 3_Generate.py
@@ -40,6 +40,8 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: "recursive"
+      - name: install graphviz
+        run: choco install graphviz
       - name: run
         run: |
           python Sources/CPFBuildScripts/0_CopyScripts.py

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -8,9 +8,9 @@ jobs:
       matrix:
         config: [Gcc-shared-debug, Clang-shared-debug, Clang-static-release]
     steps:
-      - name: Install setuptools
-        run: sudo apt-get install python3-setuptools graphviz
-      - name: install
+      - name: Install system packages
+        run: sudo apt-get install python3-setuptools graphviz clang-format-10 clang-10
+      - name: install conan
         run: pip3 install conan --ignore-installed 
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -14,9 +14,8 @@ jobs:
         run: pip3 install conan --ignore-installed 
       - uses: actions/checkout@v2
         with:
-          submodules: True
+          submodules: recursive
       - name: run
-        shell: bash
         env:
           CONAN_SYSREQUIRES_MODE: enabled
           CONAN_SYSREQUIRES_SUDO: 0
@@ -24,8 +23,8 @@ jobs:
           pwd
           ls -al ./
           ls -al Sources/
-          sudo ls -al Sources/CPFBuildScripts/
-          sudo ls -al Sources/CPFBuildScripts/0_CopyScripts.py
+          ls -al Sources/CPFBuildScripts/
+          ls -al Sources/CPFBuildScripts/0_CopyScripts.py
           python3 1_Configure.py ${{ matrix.config }}
           python3 3_Generate.py
           python3 4_Make.py --target runAllTests_QtTestConsumer
@@ -39,7 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          submodules: "recursive"
+          submodules: recursive
       - name: run
         run: |
           python Sources/CPFBuildScripts/0_CopyScripts.py

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -9,7 +9,7 @@ jobs:
         config: [Gcc-shared-debug, Clang-shared-debug, Clang-static-release]
     steps:
       - name: Install system packages
-        run: sudo apt-get install python3-setuptools graphviz clang-format-10 clang-10 clang-tidy-10 ninja
+        run: sudo apt-get install python3-setuptools graphviz clang-format-10 clang-10 clang-tidy-10 ninja-build
       - name: install conan
         run: pip3 install conan --ignore-installed 
       - uses: actions/checkout@v2

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -22,8 +22,10 @@ jobs:
           CONAN_SYSREQUIRES_SUDO: 0
         run: |
           pwd
-          ls
-          python3 Sources/CPFBuildScripts/0_CopyScripts.py
+          ls -al
+          ls -al Sources
+          ls -al Sources/CPFBuildScripts
+          ls -al Sources/CPFBuildScripts/0_CopyScripts.py
           python3 1_Configure.py ${{ matrix.config }}
           python3 3_Generate.py
           python3 4_Make.py --target runAllTests_QtTestConsumer

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -32,7 +32,7 @@ jobs:
           CONAN_SYSREQUIRES_SUDO: 0
         run: |
           pushd Sources && ls -al && popd
-          python3 Sources/CPFBuildScripts/0_CopyScripts.py
+          python3 Sources/CPFBuildscripts/0_CopyScripts.py
           python3 1_Configure.py ${{ matrix.config }}
           python3 3_Generate.py
           python3 4_Make.py --target runAllTests_QtTestConsumer

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -21,6 +21,8 @@ jobs:
           CONAN_SYSREQUIRES_MODE: enabled
           CONAN_SYSREQUIRES_SUDO: 0
         run: |
+          pwd
+          ls
           python3 Sources/CPFBuildScripts/0_CopyScripts.py
           python3 1_Configure.py ${{ matrix.config }}
           python3 3_Generate.py

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -20,11 +20,8 @@ jobs:
           CONAN_SYSREQUIRES_MODE: enabled
           CONAN_SYSREQUIRES_SUDO: 0
         run: |
-          pwd
-          ls -al ./
-          ls -al Sources/
-          ls -al Sources/CPFBuildScripts/
-          ls -al Sources/CPFBuildScripts/0_CopyScripts.py
+          pushd Sources && ls -al && popd
+          pushd Sources/CPFBuildScripts/ && ls -al && popd
           python3 1_Configure.py ${{ matrix.config }}
           python3 3_Generate.py
           python3 4_Make.py --target runAllTests_QtTestConsumer

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -24,8 +24,8 @@ jobs:
           pwd
           ls -al ./
           ls -al Sources/
-          ls -al Sources/CPFBuildScripts/
-          ls -al Sources/CPFBuildScripts/0_CopyScripts.py
+          sudo ls -al Sources/CPFBuildScripts/
+          sudo ls -al Sources/CPFBuildScripts/0_CopyScripts.py
           python3 1_Configure.py ${{ matrix.config }}
           python3 3_Generate.py
           python3 4_Make.py --target runAllTests_QtTestConsumer
@@ -40,8 +40,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: "recursive"
-      - name: install graphviz
-        run: choco install graphviz
       - name: run
         run: |
           python Sources/CPFBuildScripts/0_CopyScripts.py

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -8,11 +8,11 @@ jobs:
       matrix:
         config: ["Gcc-shared-debug", "Clang-shared-debug", "Clang-static-release"]
     steps:
-      - name: Install Python
-        run: apt-get update && apt-get -qq install -y --no-install-recommends python3-pip python3-setuptools g++ pkg-config cmake
       - name: install
         run: pip3 install conan --ignore-installed 
       - uses: actions/checkout@v1
+        with:
+          submodules: "recursive"
       - name: run
         shell: bash
         env:
@@ -32,6 +32,8 @@ jobs:
         config: ["VS2019-shared-debug", "VS2019-static-release"]
     steps:
       - uses: actions/checkout@v1
+        with:
+          submodules: "recursive"
       - name: run
         run: |
           python Sources/CPFBuildScripts/0_CopyScripts.py


### PR DESCRIPTION
Currently, windows fails because it cannot find acyclic graphviz binary (I tried https://chocolatey.org/packages/Graphviz but it seems acyclic is not packaged). How can this be disabled ? Alternatively do you know a simple way to install it on windows?
Linux fails with https://github.com/ericLemanissier/ConanQtPackageTest/runs/1274746627?check_suite_focus=true#step:5:44
```
CMake Error at CPFCMake/Modules/cpfMiscUtilities.cmake:49 (cpfRightSideOfString):
  cpfRightSideOfString Function invoked with incorrect arguments for function
  named: cpfRightSideOfString
Call Stack (most recent call first):
  CPFCMake/Modules/cpfAddPackages.cmake:118 (cpfFindRequiredTools)
  CPFCMake/Modules/cpfAddPackages.cmake:35 (cpfInitGlobalState)
  CMakeLists.txt:6 (cpfAddPackages)
```